### PR TITLE
add path parameter and query parameter scenario code

### DIFF
--- a/nav2-usability/scenario-code/deeplink-pathparam/router.dart
+++ b/nav2-usability/scenario-code/deeplink-pathparam/router.dart
@@ -1,0 +1,271 @@
+// Copyright 2020, the Flutter project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Full sample that shows a custom RouteInformationParser and RouterDelegate
+/// parsing named routes and declaratively building the stack of pages for the
+/// [Navigator].
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(BooksApp());
+}
+
+class Book {
+  final String title;
+  final String author;
+
+  Book(this.title, this.author);
+}
+
+class BooksApp extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() => _BooksAppState();
+}
+
+class _BooksAppState extends State<BooksApp> {
+  final BookRouterDelegate _routerDelegate = BookRouterDelegate();
+  final BookRouteInformationParser _routeInformationParser =
+  BookRouteInformationParser();
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp.router(
+      title: 'Books App',
+      routerDelegate: _routerDelegate,
+      routeInformationParser: _routeInformationParser,
+    );
+  }
+}
+
+class BookRouteInformationParser extends RouteInformationParser<BookRoutePath> {
+  @override
+  Future<BookRoutePath> parseRouteInformation(
+      RouteInformation routeInformation) async {
+    final uri = Uri.parse(routeInformation.location!);
+    print('parseRouteInformation');
+    print('location = ${uri.path}');
+    // Handle '/'
+    if (uri.pathSegments.length == 0) {
+      return BookRoutePath.home();
+    }
+
+    // Handle '/book/:id'
+    if (uri.pathSegments.length == 2) {
+      if (uri.pathSegments[0] != 'book') return BookRoutePath.unknown();
+      final remaining = uri.pathSegments[1];
+      final id = int.tryParse(remaining);
+      if (id == null) return BookRoutePath.unknown();
+      return BookRoutePath.details(id);
+    }
+
+    // Handle unknown routes
+    return BookRoutePath.unknown();
+  }
+
+  @override
+  RouteInformation restoreRouteInformation(BookRoutePath path) {
+    late final String location;
+    if (path.isUnknown) {
+      location = '/404';
+    }
+    if (path.isHomePage) {
+      location = '/';
+    }
+    if (path.isDetailsPage) {
+      location = '/book/${path.id}';
+    }
+    print('restoreRouteInformation');
+    print('location = $location');
+    return RouteInformation(location: location);
+  }
+}
+
+class BookRouterDelegate extends RouterDelegate<BookRoutePath>
+    with ChangeNotifier, PopNavigatorRouterDelegateMixin<BookRoutePath> {
+  final GlobalKey<NavigatorState> navigatorKey;
+
+  Book? _selectedBook;
+  bool show404 = false;
+
+  List<Book> books = [
+    Book('Stranger in a Strange Land', 'Robert A. Heinlein'),
+    Book('Foundation', 'Isaac Asimov'),
+    Book('Fahrenheit 451', 'Ray Bradbury'),
+  ];
+
+  BookRouterDelegate() : navigatorKey = GlobalKey<NavigatorState>();
+
+  BookRoutePath get currentConfiguration {
+    if (show404) {
+      return BookRoutePath.unknown();
+    }
+    final selectedBook = _selectedBook;
+    if (selectedBook == null) {
+      return BookRoutePath.home();
+    } else {
+      return BookRoutePath.details(books.indexOf(selectedBook));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedBook = _selectedBook;
+    return Navigator(
+      key: navigatorKey,
+      pages: [
+        MaterialPage(
+          key: ValueKey('BooksListPage'),
+          child: BooksListScreen(
+            books: books,
+            onTapped: _handleBookTapped,
+          ),
+        ),
+        if (show404)
+          MaterialPage(key: ValueKey('UnknownPage'), child: UnknownScreen())
+        else if (selectedBook != null)
+          BookDetailsPage(book: selectedBook)
+      ],
+      onPopPage: (route, result) {
+        if (!route.didPop(result)) {
+          return false;
+        }
+
+        // Update the list of pages by setting _selectedBook to null
+        _selectedBook = null;
+        show404 = false;
+        notifyListeners();
+
+        return true;
+      },
+    );
+  }
+
+  @override
+  Future<void> setNewRoutePath(BookRoutePath path) async {
+    if (path.isUnknown) {
+      _selectedBook = null;
+      show404 = true;
+      return;
+    }
+
+    if (path.isDetailsPage) {
+      final id = path.id;
+      if (id == null || id < 0 || id > books.length - 1) {
+        show404 = true;
+        return;
+      }
+
+      _selectedBook = books[id];
+    } else {
+      _selectedBook = null;
+    }
+
+    show404 = false;
+  }
+
+  void _handleBookTapped(Book book) {
+    _selectedBook = book;
+    notifyListeners();
+  }
+}
+
+class BookDetailsPage extends Page<dynamic> {
+  final Book book;
+
+  BookDetailsPage({
+    required this.book,
+  }) : super(key: ValueKey(book));
+
+  Route<dynamic> createRoute(BuildContext context) {
+    return MaterialPageRoute(
+      settings: this,
+      builder: (BuildContext context) {
+        return BookDetailsScreen(book: book);
+      },
+    );
+  }
+}
+
+class BookRoutePath {
+  final int? id;
+  final bool isUnknown;
+
+  BookRoutePath.home()
+      : id = null,
+        isUnknown = false;
+
+  BookRoutePath.details(this.id) : isUnknown = false;
+
+  BookRoutePath.unknown()
+      : id = null,
+        isUnknown = true;
+
+  bool get isHomePage => id == null;
+
+  bool get isDetailsPage => id != null;
+}
+
+class BooksListScreen extends StatelessWidget {
+  final List<Book> books;
+  final ValueChanged<Book> onTapped;
+
+  BooksListScreen({
+    required this.books,
+    required this.onTapped,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(),
+      body: ListView(
+        children: [
+          for (var book in books)
+            ListTile(
+              title: Text(book.title),
+              subtitle: Text(book.author),
+              onTap: () => onTapped(book),
+            )
+        ],
+      ),
+    );
+  }
+}
+
+class BookDetailsScreen extends StatelessWidget {
+  final Book book;
+
+  BookDetailsScreen({
+    required this.book,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(),
+      body: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(book.title, style: Theme.of(context).textTheme.headline6),
+            Text(book.author, style: Theme.of(context).textTheme.subtitle1),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class UnknownScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(),
+      body: Center(
+        child: Text('404!'),
+      ),
+    );
+  }
+}

--- a/nav2-usability/scenario-code/deeplink-queryparam/router.dart
+++ b/nav2-usability/scenario-code/deeplink-queryparam/router.dart
@@ -1,0 +1,155 @@
+// Copyright 2020, the Flutter project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Full sample that shows a custom RouteInformationParser and RouterDelegate
+/// parsing named routes and declaratively building the stack of pages for the
+/// [Navigator].
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(BooksApp());
+}
+
+class Book {
+  final String title;
+  final String author;
+
+  Book(this.title, this.author);
+}
+
+class BooksApp extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() => _BooksAppState();
+}
+
+class _BooksAppState extends State<BooksApp> {
+  final BookRouterDelegate _routerDelegate = BookRouterDelegate();
+  final BookRouteInformationParser _routeInformationParser =
+  BookRouteInformationParser();
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp.router(
+      title: 'Books App',
+      routerDelegate: _routerDelegate,
+      routeInformationParser: _routeInformationParser,
+    );
+  }
+}
+
+class BookRouteInformationParser extends RouteInformationParser<BookRoutePath> {
+  @override
+  Future<BookRoutePath> parseRouteInformation(
+      RouteInformation routeInformation) async {
+    final uri = Uri.parse(routeInformation.location!);
+    print('parseRouteInformation');
+    print('location = ${uri.path}');
+    var filter = uri.queryParameters['filter'];
+    return BookRoutePath(filter);
+  }
+
+  @override
+  RouteInformation restoreRouteInformation(BookRoutePath path) {
+    late final String location;
+    var filter = path.filter;
+    if (filter != null) {
+      location = '/?filter=${filter}';
+    } else {
+      location = '/';
+    }
+    print('restoreRouteInformation');
+    print('location = $location');
+    return RouteInformation(location: location);
+  }
+}
+
+class BookRouterDelegate extends RouterDelegate<BookRoutePath>
+    with ChangeNotifier, PopNavigatorRouterDelegateMixin<BookRoutePath> {
+  final GlobalKey<NavigatorState> navigatorKey;
+
+  List<Book> books = [
+    Book('Stranger in a Strange Land', 'Robert A. Heinlein'),
+    Book('Foundation', 'Isaac Asimov'),
+    Book('Fahrenheit 451', 'Ray Bradbury'),
+  ];
+
+  String? filter;
+
+  BookRouterDelegate() : navigatorKey = GlobalKey<NavigatorState>();
+
+  BookRoutePath get currentConfiguration {
+    return BookRoutePath(filter);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Navigator(
+      key: navigatorKey,
+      pages: [
+        MaterialPage(
+          key: ValueKey('BooksListPage'),
+          child: BooksListScreen(
+            books: books,
+            filter: filter,
+            onFilterChanged: (filter) {
+              this.filter = filter;
+              notifyListeners();
+            },
+          ),
+        ),
+      ],
+      onPopPage: (route, result) {
+        return route.didPop(result);
+      },
+    );
+  }
+
+  @override
+  Future<void> setNewRoutePath(BookRoutePath path) async {
+    filter = path.filter;
+  }
+}
+
+class BookRoutePath {
+  String? filter;
+
+  BookRoutePath(this.filter);
+}
+
+class BooksListScreen extends StatelessWidget {
+  final List<Book> books;
+  final String? filter;
+  final ValueChanged onFilterChanged;
+
+  BooksListScreen({
+    required this.books,
+    required this.onFilterChanged,
+    this.filter,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final filter = this.filter;
+    print('filter = $filter');
+    return Scaffold(
+      appBar: AppBar(),
+      body: ListView(
+        children: [
+          TextField(
+            decoration: InputDecoration(
+              hintText: 'filter',
+            ),
+            onChanged: this.onFilterChanged,
+          ),
+          for (var book in books)
+            if (filter == null || book.title.toLowerCase().contains(filter))
+              ListTile(
+                title: Text(book.title),
+                subtitle: Text(book.author),
+              )
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Adds the first two scenario code snippets. The path parameter snippet is more or less the same as the [router sample from flutter/samples](https://github.com/flutter/samples/blob/master/navigation_and_routing/lib/router/router.dart) and the query parameter snippet is simplified to only be a filter on the list.

These can be run in DartPad, but in order to show the URL I had to add print statements, since DartPad won't show that unless you inspect the iframe.