### PR TITLE
Dynamic linking, Skipping stacks, and bump pathparams & queryparams to 2.0.2 

### DIFF
--- a/nav2-usability/scenario_code/lib/deeplink-pathparam/deeplink_pathparam_auto_route.dart
+++ b/nav2-usability/scenario_code/lib/deeplink-pathparam/deeplink_pathparam_auto_route.dart
@@ -6,7 +6,7 @@
 /// Done using AutoRoute
 import 'package:flutter/material.dart';
 import 'package:auto_route/auto_route.dart';
-import 'deeplink_pathparam_auto_route.gr.dart';
+import 'package:flutter_uxr/main.gr.dart';
 
 void main() {
   runApp(BooksApp());
@@ -65,7 +65,7 @@ class _BooksListScreenState extends State<BooksListScreen> {
               title: Text(book.title),
               subtitle: Text(book.author),
               onTap: () =>
-                  context.router.replace(BookDetailsRoute(id: books.indexOf(book))),
+                  context.router.pushNamed("/book/${books.indexOf(book)}"),
             )
         ],
       ),

--- a/nav2-usability/scenario_code/lib/deeplink-pathparam/deeplink_pathparam_auto_route.dart
+++ b/nav2-usability/scenario_code/lib/deeplink-pathparam/deeplink_pathparam_auto_route.dart
@@ -6,7 +6,7 @@
 /// Done using AutoRoute
 import 'package:flutter/material.dart';
 import 'package:auto_route/auto_route.dart';
-import 'package:flutter_uxr/main.gr.dart';
+import 'deeplink_pathparam_auto_route.gr.dart';
 
 void main() {
   runApp(BooksApp());

--- a/nav2-usability/scenario_code/lib/deeplink-pathparam/deeplink_pathparam_auto_route.dart
+++ b/nav2-usability/scenario_code/lib/deeplink-pathparam/deeplink_pathparam_auto_route.dart
@@ -43,7 +43,7 @@ class BooksApp extends StatelessWidget {
 
     return MaterialApp.router(
       routerDelegate: _appRouter.delegate(),
-      routeInformationParser: _appRouter.defaultRouteParser(),
+      routeInformationParser: _appRouter.defaultRouteParser(includePrefixMatches: true),
     );
   }
 }

--- a/nav2-usability/scenario_code/lib/deeplink-pathparam/deeplink_pathparam_auto_route.gr.dart
+++ b/nav2-usability/scenario_code/lib/deeplink-pathparam/deeplink_pathparam_auto_route.gr.dart
@@ -7,7 +7,7 @@
 import 'package:auto_route/auto_route.dart' as _i1;
 import 'package:flutter/material.dart' as _i2;
 
-import 'deeplink_pathparam_auto_route.dart' as _i3;
+import 'main.dart' as _i3;
 
 class AppRouter extends _i1.RootStackRouter {
   AppRouter([_i2.GlobalKey<_i2.NavigatorState>? navigatorKey])

--- a/nav2-usability/scenario_code/lib/deeplink-queryparam/deeplink_queryparam_auto_route.dart
+++ b/nav2-usability/scenario_code/lib/deeplink-queryparam/deeplink_queryparam_auto_route.dart
@@ -2,11 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// Queryparam path parameters example
+/// Deeplink query parameters example
 /// Done using AutoRoute
 import 'package:flutter/material.dart';
 import 'package:auto_route/auto_route.dart';
-import 'deeplink_queryparam_auto_route.gr.dart';
+import 'package:flutter_uxr/main.gr.dart';
 
 void main() {
   runApp(BooksApp());
@@ -30,6 +30,7 @@ class Book {
   replaceInRouteName: 'Screen,Route',
   routes: <AutoRoute>[
     AutoRoute(path: "/", page: BooksListScreen),
+    AutoRoute(path: "/book/:id", page: BookDetailsScreen),
     RedirectRoute(path: "*", redirectTo: "/")
   ],
 )
@@ -47,29 +48,50 @@ class BooksApp extends StatelessWidget {
   }
 }
 
-class BooksListScreen extends StatelessWidget {
-  final String? filter;
-  BooksListScreen({@QueryParam('filter') this.filter});
+class BooksListScreen extends StatefulWidget {
+  @override
+  _BooksListScreenState createState() => _BooksListScreenState();
+}
 
+class _BooksListScreenState extends State<BooksListScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(),
       body: ListView(
         children: [
-          TextField(
-            decoration: InputDecoration(
-              hintText: 'filter',
-            ),
-            onSubmitted: (value) => context.router.pushPath('/?filter=$value'),
-          ),
           for (var book in books)
-            if (filter == null || book.title.toLowerCase().contains(filter!))
-              ListTile(
-                title: Text(book.title),
-                subtitle: Text(book.author),
-              )
+            ListTile(
+              title: Text(book.title),
+              subtitle: Text(book.author),
+              onTap: () =>
+                  context.router.replaceNamed("/book/${books.indexOf(book)}"),
+            )
         ],
+      ),
+    );
+  }
+}
+
+class BookDetailsScreen extends StatelessWidget {
+  final int id;
+
+  BookDetailsScreen({@PathParam('id') required this.id});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(),
+      body: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(books[id].title, style: Theme.of(context).textTheme.headline6),
+            Text(books[id].author,
+                style: Theme.of(context).textTheme.subtitle1),
+          ],
+        ),
       ),
     );
   }

--- a/nav2-usability/scenario_code/lib/deeplink-queryparam/deeplink_queryparam_auto_route.dart
+++ b/nav2-usability/scenario_code/lib/deeplink-queryparam/deeplink_queryparam_auto_route.dart
@@ -6,7 +6,7 @@
 /// Done using AutoRoute
 import 'package:flutter/material.dart';
 import 'package:auto_route/auto_route.dart';
-import 'package:flutter_uxr/main.gr.dart';
+import 'deeplink_queryparam_auto_route.gr.dart';
 
 void main() {
   runApp(BooksApp());

--- a/nav2-usability/scenario_code/lib/deeplink-queryparam/deeplink_queryparam_auto_route.dart
+++ b/nav2-usability/scenario_code/lib/deeplink-queryparam/deeplink_queryparam_auto_route.dart
@@ -30,7 +30,6 @@ class Book {
   replaceInRouteName: 'Screen,Route',
   routes: <AutoRoute>[
     AutoRoute(path: "/", page: BooksListScreen),
-    AutoRoute(path: "/book/:id", page: BookDetailsScreen),
     RedirectRoute(path: "*", redirectTo: "/")
   ],
 )
@@ -48,50 +47,30 @@ class BooksApp extends StatelessWidget {
   }
 }
 
-class BooksListScreen extends StatefulWidget {
-  @override
-  _BooksListScreenState createState() => _BooksListScreenState();
-}
+class BooksListScreen extends StatelessWidget {
+  final String? filter;
+  BooksListScreen({@QueryParam('filter') this.filter});
 
-class _BooksListScreenState extends State<BooksListScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(),
       body: ListView(
         children: [
+          TextField(
+            decoration: InputDecoration(
+              hintText: 'filter',
+            ),
+            onSubmitted: (value) =>
+                context.router.replaceNamed('/?filter=$value'),
+          ),
           for (var book in books)
-            ListTile(
-              title: Text(book.title),
-              subtitle: Text(book.author),
-              onTap: () =>
-                  context.router.replaceNamed("/book/${books.indexOf(book)}"),
-            )
+            if (filter == null || book.title.toLowerCase().contains(filter!))
+              ListTile(
+                title: Text(book.title),
+                subtitle: Text(book.author),
+              )
         ],
-      ),
-    );
-  }
-}
-
-class BookDetailsScreen extends StatelessWidget {
-  final int id;
-
-  BookDetailsScreen({@PathParam('id') required this.id});
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(),
-      body: Padding(
-        padding: const EdgeInsets.all(8.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(books[id].title, style: Theme.of(context).textTheme.headline6),
-            Text(books[id].author,
-                style: Theme.of(context).textTheme.subtitle1),
-          ],
-        ),
       ),
     );
   }

--- a/nav2-usability/scenario_code/lib/deeplink-queryparam/deeplink_queryparam_auto_route.gr.dart
+++ b/nav2-usability/scenario_code/lib/deeplink-queryparam/deeplink_queryparam_auto_route.gr.dart
@@ -7,7 +7,7 @@
 import 'package:auto_route/auto_route.dart' as _i1;
 import 'package:flutter/material.dart' as _i2;
 
-import 'deeplink_queryparam_auto_route.dart' as _i3;
+import 'main.dart' as _i3;
 
 class AppRouter extends _i1.RootStackRouter {
   AppRouter([_i2.GlobalKey<_i2.NavigatorState>? navigatorKey])

--- a/nav2-usability/scenario_code/lib/dynamic-linking/dynamic_linking_auto_route.dart
+++ b/nav2-usability/scenario_code/lib/dynamic-linking/dynamic_linking_auto_route.dart
@@ -1,0 +1,148 @@
+// Copyright 2021, the Flutter project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+//
+/// Dynamic linking example
+/// Done using AutoRoute
+
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter_uxr/main.gr.dart';
+
+void main() {
+  runApp(WishListApp());
+}
+
+class Wishlist {
+  final String id;
+
+  Wishlist(this.id);
+}
+
+class AppState extends ChangeNotifier {
+  final List<Wishlist> wishlists = <Wishlist>[];
+
+  void addWishlist(Wishlist wishlist) {
+    wishlists.add(wishlist);
+    notifyListeners();
+  }
+}
+
+// Declare routing setup
+@MaterialAutoRouter(
+  replaceInRouteName: 'Screen,Route',
+  routes: <AutoRoute>[
+    AutoRoute(
+      path: "/",
+      page: WishlistListScreen,
+    ),
+    AutoRoute(
+      path: "/wishlist/:id",
+      guards: [CreateIfNotExistGuard],
+      page: WishlistScreen,
+    ),
+    RedirectRoute(path: "*", redirectTo: "/")
+  ],
+)
+class $AppRouter {}
+
+class CreateIfNotExistGuard extends AutoRouteGuard {
+  @override
+  Future<bool> canNavigate(
+      List<PageRouteInfo> pendingRoutes, StackRouter router) async {
+    final id = pendingRoutes.first.params["id"];
+    if (appState.wishlists.indexWhere((element) => element.id == id) == -1) {
+      appState.addWishlist(Wishlist(id));
+    }
+    return true;
+  }
+}
+
+final AppState appState = AppState();
+
+class WishListApp extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() => _WishListAppState();
+}
+
+class _WishListAppState extends State<WishListApp> {
+  late final _appRouter = AppRouter(
+    createIfNotExistGuard: CreateIfNotExistGuard(),
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp.router(
+      routeInformationParser:
+          // includePrefixMatches can toggle whether the root / route is also pushed when you
+          // hit /wishlist/:id directly in the browser
+          _appRouter.defaultRouteParser(includePrefixMatches: true),
+      routerDelegate: _appRouter.delegate(),
+    );
+  }
+}
+
+class WishlistListScreen extends StatelessWidget {
+  void onCreate(BuildContext context, String value) {
+    final wishlist = Wishlist(value);
+    appState.addWishlist(wishlist);
+    context.router.pushNamed('/wishlist/$value');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(),
+      body: ListView(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child:
+                Text('Navigate to /wishlist/<ID> in the URL bar to dynamically '
+                    'create a new wishlist.'),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: ElevatedButton(
+              onPressed: () {
+                var randomInt = Random().nextInt(10000);
+                onCreate(context, '$randomInt');
+              },
+              child: Text('Create a new Wishlist'),
+            ),
+          ),
+          for (var i = 0; i < appState.wishlists.length; i++)
+            ListTile(
+              title: Text('Wishlist ${i + 1}'),
+              subtitle: Text(appState.wishlists[i].id),
+              onTap: () => context.router
+                  .pushNamed("/wishlist/${appState.wishlists[i].id}"),
+            )
+        ],
+      ),
+    );
+  }
+}
+
+class WishlistScreen extends StatelessWidget {
+  WishlistScreen({@PathParam('id') required this.id});
+  final String id;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(),
+      body: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('ID: $id', style: Theme.of(context).textTheme.headline6),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/nav2-usability/scenario_code/lib/dynamic-linking/dynamic_linking_auto_route.dart
+++ b/nav2-usability/scenario_code/lib/dynamic-linking/dynamic_linking_auto_route.dart
@@ -9,7 +9,7 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:auto_route/auto_route.dart';
-import 'package:flutter_uxr/main.gr.dart';
+import 'dynamic_linking_auto_route.gr.dart';
 
 void main() {
   runApp(WishListApp());

--- a/nav2-usability/scenario_code/lib/dynamic-linking/dynamic_linking_auto_route.gr.dart
+++ b/nav2-usability/scenario_code/lib/dynamic-linking/dynamic_linking_auto_route.gr.dart
@@ -1,0 +1,65 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// **************************************************************************
+// AutoRouteGenerator
+// **************************************************************************
+
+import 'package:auto_route/auto_route.dart' as _i1;
+import 'package:flutter/material.dart' as _i2;
+
+import 'main.dart' as _i3;
+
+class AppRouter extends _i1.RootStackRouter {
+  AppRouter(
+      {_i2.GlobalKey<_i2.NavigatorState>? navigatorKey,
+      required this.createIfNotExistGuard})
+      : super(navigatorKey);
+
+  final _i3.CreateIfNotExistGuard createIfNotExistGuard;
+
+  @override
+  final Map<String, _i1.PageFactory> pagesMap = {
+    WishlistListRoute.name: (routeData) {
+      return _i1.MaterialPageX<dynamic>(
+          routeData: routeData, child: _i3.WishlistListScreen());
+    },
+    WishlistRoute.name: (routeData) {
+      var pathParams = routeData.pathParams;
+      final args = routeData.argsAs<WishlistRouteArgs>(
+          orElse: () => WishlistRouteArgs(id: pathParams.getString('id')));
+      return _i1.MaterialPageX<dynamic>(
+          routeData: routeData, child: _i3.WishlistScreen(id: args.id));
+    }
+  };
+
+  @override
+  List<_i1.RouteConfig> get routes => [
+        _i1.RouteConfig(WishlistListRoute.name, path: '/'),
+        _i1.RouteConfig(WishlistRoute.name,
+            path: '/wishlist/:id', guards: [createIfNotExistGuard]),
+        _i1.RouteConfig('*#redirect',
+            path: '*', redirectTo: '/', fullMatch: true)
+      ];
+}
+
+class WishlistListRoute extends _i1.PageRouteInfo {
+  const WishlistListRoute() : super(name, path: '/');
+
+  static const String name = 'WishlistListRoute';
+}
+
+class WishlistRoute extends _i1.PageRouteInfo<WishlistRouteArgs> {
+  WishlistRoute({required String id})
+      : super(name,
+            path: '/wishlist/:id',
+            args: WishlistRouteArgs(id: id),
+            params: {'id': id});
+
+  static const String name = 'WishlistRoute';
+}
+
+class WishlistRouteArgs {
+  const WishlistRouteArgs({required this.id});
+
+  final String id;
+}

--- a/nav2-usability/scenario_code/lib/skipping-stacks/skipping_stacks_auto_route.dart
+++ b/nav2-usability/scenario_code/lib/skipping-stacks/skipping_stacks_auto_route.dart
@@ -40,27 +40,21 @@ class AppState extends ChangeNotifier {
   replaceInRouteName: 'Screen,Route',
   routes: <AutoRoute>[
     AutoRoute(
-        path: '/',
-        name: 'RootRouter',
-        page: EmptyRouterScreen,
-        children: [
-          AutoRoute(
-            path: '',
-            page: BooksListScreen,
-          ),
-          AutoRoute(
-            path: 'book/:bookId',
-            page: BookDetailsScreen,
-          ),
-          AutoRoute(
-            path: 'authors',
-            page: AuthorsListScreen,
-          ),
-          AutoRoute(
-            path: 'author/:bookId',
-            page: AuthorDetailsScreen,
-          ),
-        ]),
+      path: '/',
+      page: BooksListScreen,
+    ),
+    AutoRoute(
+      path: '/book/:bookId',
+      page: BookDetailsScreen,
+    ),
+    AutoRoute(
+      path: '/authors',
+      page: AuthorsListScreen,
+    ),
+    AutoRoute(
+      path: '/author/:bookId',
+      page: AuthorDetailsScreen,
+    ),
     RedirectRoute(path: "*", redirectTo: "/")
   ],
 )
@@ -92,8 +86,8 @@ class BooksListScreen extends StatelessWidget {
             ListTile(
               title: Text(book.title),
               subtitle: Text(book.author.name),
-              onTap: () => context.router
-                  .push(BookDetailsRoute(bookId: books.indexOf(book))),
+              onTap: () =>
+                  context.router.pushNamed("/book/${books.indexOf(book)}"),
             )
         ],
       ),
@@ -110,14 +104,14 @@ class AuthorsListScreen extends StatelessWidget {
       body: ListView(
         children: [
           ElevatedButton(
-            onPressed: () => context.router.push(BooksListRoute()),
+            onPressed: () => context.router.pushNamed("/"),
             child: Text('Go to Books Page'),
           ),
           for (var author in authors)
             ListTile(
               title: Text(author.name),
               onTap: () => context.router
-                  .push(AuthorDetailsRoute(bookId: authors.indexOf(author))),
+                  .pushNamed("/author/${authors.indexOf(author)}"),
             )
         ],
       ),
@@ -143,10 +137,10 @@ class BookDetailsScreen extends StatelessWidget {
             Text(book.title, style: Theme.of(context).textTheme.headline6),
             ElevatedButton(
               // push both the AuthorsListRoute and AuthorsDetailsRoute
-              onPressed: () => context.router.push(RootRouter(children: [
+              onPressed: () => context.router.pushAll([
                 AuthorsListRoute(),
-                AuthorDetailsRoute(bookId: bookId)
-              ])),
+                AuthorDetailsRoute(bookId: bookId),
+              ]),
               child: Text(book.author.name),
             ),
           ],

--- a/nav2-usability/scenario_code/lib/skipping-stacks/skipping_stacks_auto_route.dart
+++ b/nav2-usability/scenario_code/lib/skipping-stacks/skipping_stacks_auto_route.dart
@@ -68,7 +68,7 @@ class BooksApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp.router(
-      routeInformationParser: _appRouter.defaultRouteParser(),
+      routeInformationParser: _appRouter.defaultRouteParser(includePrefixMatches: true),    
       routerDelegate: _appRouter.delegate(),
     );
   }

--- a/nav2-usability/scenario_code/lib/skipping-stacks/skipping_stacks_auto_route.dart
+++ b/nav2-usability/scenario_code/lib/skipping-stacks/skipping_stacks_auto_route.dart
@@ -6,7 +6,7 @@
 /// Done using AutoRoute
 import 'package:flutter/material.dart';
 import 'package:auto_route/auto_route.dart';
-import 'package:flutter_uxr/main.gr.dart';
+import 'skipping_stacks_auto_route.gr.dart';
 
 void main() {
   runApp(BooksApp());

--- a/nav2-usability/scenario_code/lib/skipping-stacks/skipping_stacks_auto_route.dart
+++ b/nav2-usability/scenario_code/lib/skipping-stacks/skipping_stacks_auto_route.dart
@@ -1,0 +1,180 @@
+// Copyright 2021, the Flutter project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Skipping stacks example
+/// Done using AutoRoute
+import 'package:flutter/material.dart';
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter_uxr/main.gr.dart';
+
+void main() {
+  runApp(BooksApp());
+}
+
+class Book {
+  final String title;
+  final Author author;
+
+  Book(this.title, this.author);
+}
+
+class Author {
+  String name;
+
+  Author(this.name);
+}
+
+class AppState extends ChangeNotifier {
+  final List<Book> books = [
+    Book('Stranger in a Strange Land', Author('Robert A. Heinlein')),
+    Book('Foundation', Author('Isaac Asimov')),
+    Book('Fahrenheit 451', Author('Ray Bradbury')),
+  ];
+
+  List<Author> get authors => [...books.map((book) => book.author)];
+}
+
+// Declare routing setup
+@MaterialAutoRouter(
+  replaceInRouteName: 'Screen,Route',
+  routes: <AutoRoute>[
+    AutoRoute(
+        path: '/',
+        name: 'RootRouter',
+        page: EmptyRouterScreen,
+        children: [
+          AutoRoute(
+            path: '',
+            page: BooksListScreen,
+          ),
+          AutoRoute(
+            path: 'book/:bookId',
+            page: BookDetailsScreen,
+          ),
+          AutoRoute(
+            path: 'authors',
+            page: AuthorsListScreen,
+          ),
+          AutoRoute(
+            path: 'author/:bookId',
+            page: AuthorDetailsScreen,
+          ),
+        ]),
+    RedirectRoute(path: "*", redirectTo: "/")
+  ],
+)
+class $AppRouter {}
+
+final AppState appState = AppState();
+
+class BooksApp extends StatelessWidget {
+  final _appRouter = AppRouter();
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp.router(
+      routeInformationParser: _appRouter.defaultRouteParser(),
+      routerDelegate: _appRouter.delegate(),
+    );
+  }
+}
+
+class BooksListScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final books = appState.books;
+    return Scaffold(
+      appBar: AppBar(),
+      body: ListView(
+        children: [
+          for (var book in books)
+            ListTile(
+              title: Text(book.title),
+              subtitle: Text(book.author.name),
+              onTap: () => context.router
+                  .push(BookDetailsRoute(bookId: books.indexOf(book))),
+            )
+        ],
+      ),
+    );
+  }
+}
+
+class AuthorsListScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final authors = appState.authors;
+    return Scaffold(
+      appBar: AppBar(),
+      body: ListView(
+        children: [
+          ElevatedButton(
+            onPressed: () => context.router.push(BooksListRoute()),
+            child: Text('Go to Books Page'),
+          ),
+          for (var author in authors)
+            ListTile(
+              title: Text(author.name),
+              onTap: () => context.router
+                  .push(AuthorDetailsRoute(bookId: authors.indexOf(author))),
+            )
+        ],
+      ),
+    );
+  }
+}
+
+class BookDetailsScreen extends StatelessWidget {
+  final int bookId;
+
+  BookDetailsScreen({@PathParam('bookId') required this.bookId});
+
+  @override
+  Widget build(BuildContext context) {
+    final book = appState.books[bookId];
+    return Scaffold(
+      appBar: AppBar(),
+      body: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(book.title, style: Theme.of(context).textTheme.headline6),
+            ElevatedButton(
+              // push both the AuthorsListRoute and AuthorsDetailsRoute
+              onPressed: () => context.router.push(RootRouter(children: [
+                AuthorsListRoute(),
+                AuthorDetailsRoute(bookId: bookId)
+              ])),
+              child: Text(book.author.name),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class AuthorDetailsScreen extends StatelessWidget {
+  final int bookId;
+
+  AuthorDetailsScreen({@PathParam('bookId') required this.bookId});
+
+  @override
+  Widget build(BuildContext context) {
+    final author = appState.authors[bookId];
+    return Scaffold(
+      appBar: AppBar(),
+      body: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(author.name, style: Theme.of(context).textTheme.headline6),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/nav2-usability/scenario_code/lib/skipping-stacks/skipping_stacks_auto_route.gr.dart
+++ b/nav2-usability/scenario_code/lib/skipping-stacks/skipping_stacks_auto_route.gr.dart
@@ -15,10 +15,6 @@ class AppRouter extends _i1.RootStackRouter {
 
   @override
   final Map<String, _i1.PageFactory> pagesMap = {
-    RootRouter.name: (routeData) {
-      return _i1.MaterialPageX<dynamic>(
-          routeData: routeData, child: const _i1.EmptyRouterScreen());
-    },
     BooksListRoute.name: (routeData) {
       return _i1.MaterialPageX<dynamic>(
           routeData: routeData, child: _i3.BooksListScreen());
@@ -49,26 +45,17 @@ class AppRouter extends _i1.RootStackRouter {
 
   @override
   List<_i1.RouteConfig> get routes => [
-        _i1.RouteConfig(RootRouter.name, path: '/', children: [
-          _i1.RouteConfig(BooksListRoute.name, path: ''),
-          _i1.RouteConfig(BookDetailsRoute.name, path: 'book/:bookId'),
-          _i1.RouteConfig(AuthorsListRoute.name, path: 'authors'),
-          _i1.RouteConfig(AuthorDetailsRoute.name, path: 'author/:bookId')
-        ]),
+        _i1.RouteConfig(BooksListRoute.name, path: '/'),
+        _i1.RouteConfig(BookDetailsRoute.name, path: '/book/:bookId'),
+        _i1.RouteConfig(AuthorsListRoute.name, path: '/authors'),
+        _i1.RouteConfig(AuthorDetailsRoute.name, path: '/author/:bookId'),
         _i1.RouteConfig('*#redirect',
             path: '*', redirectTo: '/', fullMatch: true)
       ];
 }
 
-class RootRouter extends _i1.PageRouteInfo {
-  const RootRouter({List<_i1.PageRouteInfo>? children})
-      : super(name, path: '/', children: children);
-
-  static const String name = 'RootRouter';
-}
-
 class BooksListRoute extends _i1.PageRouteInfo {
-  const BooksListRoute() : super(name, path: '');
+  const BooksListRoute() : super(name, path: '/');
 
   static const String name = 'BooksListRoute';
 }
@@ -76,7 +63,7 @@ class BooksListRoute extends _i1.PageRouteInfo {
 class BookDetailsRoute extends _i1.PageRouteInfo<BookDetailsRouteArgs> {
   BookDetailsRoute({required int bookId})
       : super(name,
-            path: 'book/:bookId',
+            path: '/book/:bookId',
             args: BookDetailsRouteArgs(bookId: bookId),
             params: {'bookId': bookId});
 
@@ -90,7 +77,7 @@ class BookDetailsRouteArgs {
 }
 
 class AuthorsListRoute extends _i1.PageRouteInfo {
-  const AuthorsListRoute() : super(name, path: 'authors');
+  const AuthorsListRoute() : super(name, path: '/authors');
 
   static const String name = 'AuthorsListRoute';
 }
@@ -98,7 +85,7 @@ class AuthorsListRoute extends _i1.PageRouteInfo {
 class AuthorDetailsRoute extends _i1.PageRouteInfo<AuthorDetailsRouteArgs> {
   AuthorDetailsRoute({required int bookId})
       : super(name,
-            path: 'author/:bookId',
+            path: '/author/:bookId',
             args: AuthorDetailsRouteArgs(bookId: bookId),
             params: {'bookId': bookId});
 

--- a/nav2-usability/scenario_code/lib/skipping-stacks/skipping_stacks_auto_route.gr.dart
+++ b/nav2-usability/scenario_code/lib/skipping-stacks/skipping_stacks_auto_route.gr.dart
@@ -1,0 +1,112 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// **************************************************************************
+// AutoRouteGenerator
+// **************************************************************************
+
+import 'package:auto_route/auto_route.dart' as _i1;
+import 'package:flutter/material.dart' as _i2;
+
+import 'main.dart' as _i3;
+
+class AppRouter extends _i1.RootStackRouter {
+  AppRouter([_i2.GlobalKey<_i2.NavigatorState>? navigatorKey])
+      : super(navigatorKey);
+
+  @override
+  final Map<String, _i1.PageFactory> pagesMap = {
+    RootRouter.name: (routeData) {
+      return _i1.MaterialPageX<dynamic>(
+          routeData: routeData, child: const _i1.EmptyRouterScreen());
+    },
+    BooksListRoute.name: (routeData) {
+      return _i1.MaterialPageX<dynamic>(
+          routeData: routeData, child: _i3.BooksListScreen());
+    },
+    BookDetailsRoute.name: (routeData) {
+      var pathParams = routeData.pathParams;
+      final args = routeData.argsAs<BookDetailsRouteArgs>(
+          orElse: () =>
+              BookDetailsRouteArgs(bookId: pathParams.getInt('bookId')));
+      return _i1.MaterialPageX<dynamic>(
+          routeData: routeData,
+          child: _i3.BookDetailsScreen(bookId: args.bookId));
+    },
+    AuthorsListRoute.name: (routeData) {
+      return _i1.MaterialPageX<dynamic>(
+          routeData: routeData, child: _i3.AuthorsListScreen());
+    },
+    AuthorDetailsRoute.name: (routeData) {
+      var pathParams = routeData.pathParams;
+      final args = routeData.argsAs<AuthorDetailsRouteArgs>(
+          orElse: () =>
+              AuthorDetailsRouteArgs(bookId: pathParams.getInt('bookId')));
+      return _i1.MaterialPageX<dynamic>(
+          routeData: routeData,
+          child: _i3.AuthorDetailsScreen(bookId: args.bookId));
+    }
+  };
+
+  @override
+  List<_i1.RouteConfig> get routes => [
+        _i1.RouteConfig(RootRouter.name, path: '/', children: [
+          _i1.RouteConfig(BooksListRoute.name, path: ''),
+          _i1.RouteConfig(BookDetailsRoute.name, path: 'book/:bookId'),
+          _i1.RouteConfig(AuthorsListRoute.name, path: 'authors'),
+          _i1.RouteConfig(AuthorDetailsRoute.name, path: 'author/:bookId')
+        ]),
+        _i1.RouteConfig('*#redirect',
+            path: '*', redirectTo: '/', fullMatch: true)
+      ];
+}
+
+class RootRouter extends _i1.PageRouteInfo {
+  const RootRouter({List<_i1.PageRouteInfo>? children})
+      : super(name, path: '/', children: children);
+
+  static const String name = 'RootRouter';
+}
+
+class BooksListRoute extends _i1.PageRouteInfo {
+  const BooksListRoute() : super(name, path: '');
+
+  static const String name = 'BooksListRoute';
+}
+
+class BookDetailsRoute extends _i1.PageRouteInfo<BookDetailsRouteArgs> {
+  BookDetailsRoute({required int bookId})
+      : super(name,
+            path: 'book/:bookId',
+            args: BookDetailsRouteArgs(bookId: bookId),
+            params: {'bookId': bookId});
+
+  static const String name = 'BookDetailsRoute';
+}
+
+class BookDetailsRouteArgs {
+  const BookDetailsRouteArgs({required this.bookId});
+
+  final int bookId;
+}
+
+class AuthorsListRoute extends _i1.PageRouteInfo {
+  const AuthorsListRoute() : super(name, path: 'authors');
+
+  static const String name = 'AuthorsListRoute';
+}
+
+class AuthorDetailsRoute extends _i1.PageRouteInfo<AuthorDetailsRouteArgs> {
+  AuthorDetailsRoute({required int bookId})
+      : super(name,
+            path: 'author/:bookId',
+            args: AuthorDetailsRouteArgs(bookId: bookId),
+            params: {'bookId': bookId});
+
+  static const String name = 'AuthorDetailsRoute';
+}
+
+class AuthorDetailsRouteArgs {
+  const AuthorDetailsRouteArgs({required this.bookId});
+
+  final int bookId;
+}


### PR DESCRIPTION
2 new snippets & 2 updated snippets

@Milad-Akarie for review

@johnpryan to address your comment about BookDetailsPage having no back button for the pathparams snippet - I'm pushing the route now so it has one now

Also, queryparam scenario i return it to `replace` since @chunhtai saying that it should replace, not push. However, I see that other libraries and pushing instead of replacing so I'm a bit confused on that.

Auth & Nesting are almost done but need Milad's input - we are working on those together and will be done very soon - sorry for cutting it this close 