### PR TITLE
Fix file names in generated code for auto_route snippets

### DIFF
--- a/nav2-usability/scenario_code/lib/deeplink-pathparam/deeplink_pathparam_auto_route.dart
+++ b/nav2-usability/scenario_code/lib/deeplink-pathparam/deeplink_pathparam_auto_route.dart
@@ -43,7 +43,8 @@ class BooksApp extends StatelessWidget {
 
     return MaterialApp.router(
       routerDelegate: _appRouter.delegate(),
-      routeInformationParser: _appRouter.defaultRouteParser(includePrefixMatches: true),
+      routeInformationParser:
+          _appRouter.defaultRouteParser(includePrefixMatches: true),
     );
   }
 }

--- a/nav2-usability/scenario_code/lib/deeplink-pathparam/deeplink_pathparam_auto_route.gr.dart
+++ b/nav2-usability/scenario_code/lib/deeplink-pathparam/deeplink_pathparam_auto_route.gr.dart
@@ -7,7 +7,7 @@
 import 'package:auto_route/auto_route.dart' as _i1;
 import 'package:flutter/material.dart' as _i2;
 
-import 'main.dart' as _i3;
+import 'deeplink_pathparam_auto_route.dart' as _i3;
 
 class AppRouter extends _i1.RootStackRouter {
   AppRouter([_i2.GlobalKey<_i2.NavigatorState>? navigatorKey])

--- a/nav2-usability/scenario_code/lib/deeplink-queryparam/deeplink_queryparam_auto_route.gr.dart
+++ b/nav2-usability/scenario_code/lib/deeplink-queryparam/deeplink_queryparam_auto_route.gr.dart
@@ -7,7 +7,7 @@
 import 'package:auto_route/auto_route.dart' as _i1;
 import 'package:flutter/material.dart' as _i2;
 
-import 'main.dart' as _i3;
+import 'deeplink_queryparam_auto_route.dart' as _i3;
 
 class AppRouter extends _i1.RootStackRouter {
   AppRouter([_i2.GlobalKey<_i2.NavigatorState>? navigatorKey])

--- a/nav2-usability/scenario_code/lib/dynamic-linking/dynamic_linking_auto_route.gr.dart
+++ b/nav2-usability/scenario_code/lib/dynamic-linking/dynamic_linking_auto_route.gr.dart
@@ -7,7 +7,7 @@
 import 'package:auto_route/auto_route.dart' as _i1;
 import 'package:flutter/material.dart' as _i2;
 
-import 'main.dart' as _i3;
+import 'dynamic_linking_auto_route.dart' as _i3;
 
 class AppRouter extends _i1.RootStackRouter {
   AppRouter(

--- a/nav2-usability/scenario_code/lib/skipping-stacks/skipping_stacks_auto_route.gr.dart
+++ b/nav2-usability/scenario_code/lib/skipping-stacks/skipping_stacks_auto_route.gr.dart
@@ -7,7 +7,7 @@
 import 'package:auto_route/auto_route.dart' as _i1;
 import 'package:flutter/material.dart' as _i2;
 
-import 'main.dart' as _i3;
+import 'skipping_stacks_auto_route.dart' as _i3;
 
 class AppRouter extends _i1.RootStackRouter {
   AppRouter([_i2.GlobalKey<_i2.NavigatorState>? navigatorKey])


### PR DESCRIPTION
I regenerated code from the auto_route snippets to fix file names referenced in the original generated code. 