### PR TITLE
Migrate beamer to v0.13

### DIFF
--- a/nav2-usability/scenario_code/lib/deeplink-pathparam/deeplink_pathparam_beamer.dart
+++ b/nav2-usability/scenario_code/lib/deeplink-pathparam/deeplink_pathparam_beamer.dart
@@ -25,7 +25,8 @@ class BooksApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp.router(
       title: 'Books App',
-      routerDelegate: BeamerRouterDelegate(
+      routerDelegate: BeamerDelegate(
+        notFoundRedirectNamed: '/',
         locationBuilder: SimpleLocationBuilder(
           routes: {
             '/': (context) => BooksListScreen(
@@ -35,14 +36,18 @@ class BooksApp extends StatelessWidget {
             '/books/:bookId': (context) {
               final bookId = int.parse(
                   context.currentBeamLocation.state.pathParameters['bookId']!);
-              return BookDetailsScreen(
-                book: books[bookId],
+              return BeamPage(
+                key: ValueKey('book-$bookId'),
+                popToNamed: '/',
+                child: BookDetailsScreen(
+                  book: books[bookId],
+                ),
               );
             },
           },
         ),
       ),
-      routeInformationParser: BeamerRouteInformationParser(),
+      routeInformationParser: BeamerParser(),
     );
   }
 }

--- a/nav2-usability/scenario_code/lib/deeplink-queryparam/deeplink-queryparam_beamer.dart
+++ b/nav2-usability/scenario_code/lib/deeplink-queryparam/deeplink-queryparam_beamer.dart
@@ -25,7 +25,7 @@ class BooksLocation extends BeamLocation {
   List<String> get pathBlueprints => ['/books'];
 
   @override
-  List<BeamPage> pagesBuilder(BuildContext context, BeamState state) => [
+  List<BeamPage> buildPages(BuildContext context, BeamState state) => [
         BeamPage(
           key: ValueKey('books-${state.queryParameters['filter'] ?? ''}'),
           child: BooksListScreen(
@@ -49,10 +49,11 @@ class BooksApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp.router(
       title: 'Books App',
-      routerDelegate: BeamerRouterDelegate(
+      routerDelegate: BeamerDelegate(
+        transitionDelegate: NoAnimationTransitionDelegate(),
         locationBuilder: (state) => BooksLocation(state),
       ),
-      routeInformationParser: BeamerRouteInformationParser(),
+      routeInformationParser: BeamerParser(),
     );
   }
 }

--- a/nav2-usability/scenario_code/lib/dynamic-linking/dynamic_linking_beamer.dart
+++ b/nav2-usability/scenario_code/lib/dynamic-linking/dynamic_linking_beamer.dart
@@ -55,7 +55,7 @@ class WishlistLocation extends BeamLocation {
   List<String> get pathBlueprints => ['/wishlist/:wishlistId'];
 
   @override
-  List<BeamPage> pagesBuilder(BuildContext context, BeamState beamState) => [
+  List<BeamPage> buildPages(BuildContext context, BeamState beamState) => [
         BeamPage(
           key: ValueKey('wishlist-${_appState.wishlists.length}'),
           child: WishlistListScreen(
@@ -93,11 +93,11 @@ class WishlistApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp.router(
       title: 'Wishlist App',
-      routerDelegate: BeamerRouterDelegate(
+      routerDelegate: BeamerDelegate(
         transitionDelegate: NoAnimationTransitionDelegate(),
         locationBuilder: (beamState) => WishlistLocation(_appState, beamState),
       ),
-      routeInformationParser: BeamerRouteInformationParser(),
+      routeInformationParser: BeamerParser(),
     );
   }
 }

--- a/nav2-usability/scenario_code/lib/nested-routing/nested_routing_beamer.dart
+++ b/nav2-usability/scenario_code/lib/nested-routing/nested_routing_beamer.dart
@@ -21,15 +21,18 @@ class BooksApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp.router(
       title: 'Books App',
-      routerDelegate: BeamerRouterDelegate(
+      routerDelegate: BeamerDelegate(
         initialPath: '/books/new',
         locationBuilder: SimpleLocationBuilder(
           routes: {
-            '/*/*': (context) => HomeScreen(),
+            '*': (context) => BeamPage(
+                  key: ValueKey('${context.currentBeamLocation.state.uri}'),
+                  child: HomeScreen(),
+                ),
           },
         ),
       ),
-      routeInformationParser: BeamerRouteInformationParser(),
+      routeInformationParser: BeamerParser(),
     );
   }
 }
@@ -48,7 +51,7 @@ class _HomeScreenState extends State<HomeScreen> {
     return Scaffold(
       body: Beamer(
         key: _innerBeamer,
-        routerDelegate: BeamerRouterDelegate(
+        routerDelegate: BeamerDelegate(
           transitionDelegate: NoAnimationTransitionDelegate(),
           locationBuilder: SimpleLocationBuilder(
             routes: {
@@ -117,10 +120,13 @@ class _BooksScreenState extends State<BooksScreen>
         TabController(length: 2, vsync: this, initialIndex: initialIndex)
           ..addListener(() {
             if (!_tabController.indexIsChanging) {
-              Beamer.of(context).updateRouteInformation(
-                _tabController.index == 0
-                    ? Uri.parse('/books/new')
-                    : Uri.parse('/books/all'),
+              Beamer.of(context).update(
+                state: BeamState.fromUri(
+                  _tabController.index == 0
+                      ? Uri.parse('/books/new')
+                      : Uri.parse('/books/all'),
+                ),
+                rebuild: false,
               );
             }
           });

--- a/nav2-usability/scenario_code/lib/sign-in-routing/sign_in_routing_beamer.dart
+++ b/nav2-usability/scenario_code/lib/sign-in-routing/sign_in_routing_beamer.dart
@@ -47,7 +47,7 @@ class BooksApp extends StatefulWidget {
 class _BooksAppState extends State<BooksApp> {
   final Authentication _auth = MockAuthentication();
   late final List<BeamGuard> _guards;
-  late final BeamerRouterDelegate _delegate;
+  late final BeamerDelegate _delegate;
   bool _isSignedIn = false;
 
   @override
@@ -66,7 +66,7 @@ class _BooksAppState extends State<BooksApp> {
         beamToNamed: '/',
       )
     ];
-    _delegate = BeamerRouterDelegate(
+    _delegate = BeamerDelegate(
       guards: _guards,
       locationBuilder: SimpleLocationBuilder(
         routes: {
@@ -92,7 +92,7 @@ class _BooksAppState extends State<BooksApp> {
     return MaterialApp.router(
       title: 'Books App',
       routerDelegate: _delegate,
-      routeInformationParser: BeamerRouteInformationParser(),
+      routeInformationParser: BeamerParser(),
     );
   }
 }

--- a/nav2-usability/scenario_code/lib/skipping-stacks/skipping_stacks_beamer.dart
+++ b/nav2-usability/scenario_code/lib/skipping-stacks/skipping_stacks_beamer.dart
@@ -37,7 +37,7 @@ class BooksLocation extends BeamLocation {
   List<String> get pathBlueprints => ['/books/:bookId'];
 
   @override
-  List<BeamPage> pagesBuilder(BuildContext context, BeamState state) {
+  List<BeamPage> buildPages(BuildContext context, BeamState state) {
     String? rawBookId = state.pathParameters['bookId'];
     int? bookId = rawBookId != null ? int.parse(rawBookId) : null;
     return [
@@ -85,7 +85,7 @@ class AuthorsLocation extends BeamLocation {
   List<String> get pathBlueprints => ['/authors/:authorId'];
 
   @override
-  List<BeamPage> pagesBuilder(BuildContext context, BeamState state) {
+  List<BeamPage> buildPages(BuildContext context, BeamState state) {
     String? rawAuthorId = state.pathParameters['authorId'];
     int? authorId = rawAuthorId != null ? int.parse(rawAuthorId) : null;
     return [
@@ -129,7 +129,7 @@ class BooksApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp.router(
       title: 'Books App',
-      routerDelegate: BeamerRouterDelegate(
+      routerDelegate: BeamerDelegate(
         locationBuilder: (state) {
           if (state.uri.path.contains('authors')) {
             return AuthorsLocation(state);
@@ -137,7 +137,7 @@ class BooksApp extends StatelessWidget {
           return BooksLocation(state);
         },
       ),
-      routeInformationParser: BeamerRouteInformationParser(),
+      routeInformationParser: BeamerParser(),
     );
   }
 }

--- a/nav2-usability/scenario_code/pubspec.lock
+++ b/nav2-usability/scenario_code/pubspec.lock
@@ -49,7 +49,7 @@ packages:
       name: beamer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.4"
+    version: "0.13.2"
   boolean_selector:
     dependency: transitive
     description:

--- a/nav2-usability/scenario_code/pubspec.yaml
+++ b/nav2-usability/scenario_code/pubspec.yaml
@@ -1,6 +1,6 @@
 name: scenario_code
 description: A new Flutter project.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -9,7 +9,7 @@ dependencies:
     sdk: flutter
   cupertino_icons: ^1.0.2
   vrouter: ^1.1.0
-  beamer: ^0.12.4
+  beamer: ^0.13.2
   auto_route: ^2.1.0
   navi: ^0.2.1
 dev_dependencies:


### PR DESCRIPTION
Most of the changes are renaming

- `BeamerRouterDelegate` to `BeamerDelegate`
- `BeamerRouteInformationParser` to `BeamerParser`
- `pagesBuilder` to `buildPages`

There are few slight tweaks beside that, which don't affect the overall structure and logic.