### PR TITLE
Include text for accept/reject buttons

### DIFF
--- a/surveys/contextual-survey-metadata.json
+++ b/surveys/contextual-survey-metadata.json
@@ -7,6 +7,8 @@
 	"description": "Help improve Flutter's release builds with this 3-question survey!",
 	"dismissForMinutes": "7200",
 	"moreInfoURL": "https://docs.flutter.dev/reference/crash-reporting",
+	"acceptButtonText": "Take Survey",
+	"rejectButtonText": "Dismiss",
 	"samplingRate": "0.1",
 	"conditions": [
 	    {


### PR DESCRIPTION
I decided to make it `Dismiss` instead of `Dismiss for 30 days` for the reject message since clicking dismiss will get rid of it permanently

So if the user doesn't interact with the pop up at all, the message will disappear on its own and the package will automatically handle the snooze period which is found in the `dismissForMinutes` field

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
