### PR TITLE
Additional ci check for button text uniqueness + url logic for dismiss actions

### DIFF
--- a/.github/workflows/contextual-json-validator.yml
+++ b/.github/workflows/contextual-json-validator.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 jobs:
-  json-yaml-validate:
+  contextual-json-validate:
     runs-on: ubuntu-latest
     steps:
         - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9

--- a/surveys/validator/json-validator.dart
+++ b/surveys/validator/json-validator.dart
@@ -90,6 +90,7 @@ void main() {
     }
 
     // Validation on the button array
+    final buttonTextSet = <String>{};
     for (final buttonObject in buttonList) {
       if (buttonObject is! Map) {
         throw ArgumentError('Each item in the button array must '
@@ -116,6 +117,22 @@ void main() {
       if (url != null && url.isEmpty) {
         throw ArgumentError('URL values must be a non-empty string or "null"');
       }
+
+      // If a given button has dismiss as the action, there should be no URL defined
+      if (action == 'dismiss' && url != null) {
+        throw ArgumentError('URL should be null if action for a button is '
+            '"dismiss" or "snooze" for survey: $uniqueId');
+      }
+
+      // Add the button text to the set to ensure that there are no duplicate
+      // text values for a given button (each button needs to have unique text)
+      buttonTextSet.add(buttonText);
+    }
+
+    if (buttonTextSet.length != buttonList.length) {
+      throw ArgumentError(
+          'Ensure that each survey has buttons with unique text '
+          'for survey: $uniqueId');
     }
   }
 }

--- a/surveys/validator/json-validator.dart
+++ b/surveys/validator/json-validator.dart
@@ -118,7 +118,7 @@ void main() {
         throw ArgumentError('URL values must be a non-empty string or "null"');
       }
 
-      // If a given button has "dismiss" as the action, 
+      // If a given button has "dismiss" as the action,
       // there should be no URL defined.
       if (action == 'dismiss' && url != null) {
         throw ArgumentError('URL should be null if action for a button is '

--- a/surveys/validator/json-validator.dart
+++ b/surveys/validator/json-validator.dart
@@ -118,21 +118,21 @@ void main() {
         throw ArgumentError('URL values must be a non-empty string or "null"');
       }
 
-      // If a given button has dismiss as the action, there should be no URL defined
+      // If a given button has "dismiss" as the action, 
+      // there should be no URL defined.
       if (action == 'dismiss' && url != null) {
         throw ArgumentError('URL should be null if action for a button is '
             '"dismiss" or "snooze" for survey: $uniqueId');
       }
 
-      // Add the button text to the set to ensure that there are no duplicate
-      // text values for a given button (each button needs to have unique text)
+      // Add the button text to a set to ensure that
+      // each button in a survey has a unique label.
       buttonTextSet.add(buttonText);
     }
 
     if (buttonTextSet.length != buttonList.length) {
       throw ArgumentError(
-          'Ensure that each survey has buttons with unique text '
-          'for survey: $uniqueId');
+          'Each button must have unique text in survey: $uniqueId');
     }
   }
 }


### PR DESCRIPTION
Additional ci check to ensure that each of the button texts for a given survey are unique **and** that we are not adding a `url` for buttons with `action=dismiss`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
