### PR TITLE
Include additional check in validator for uniqueId format

### DIFF
--- a/surveys/survey-validator/lib/survey_validator.dart
+++ b/surveys/survey-validator/lib/survey_validator.dart
@@ -49,7 +49,7 @@ const requiredKeys = {
   'excludeDashTools',
 };
 
-/// Regex pattern to valid UUID v4 format
+/// Regex pattern to verify a string is a valid v4 UUID.
 final uuidRegexPattern = RegExp(
     r'^[0-9a-z]{8}\-[0-9a-z]{4}\-[0-9a-z]{4}\-[0-9a-z]{4}\-[0-9a-z]{12}$');
 

--- a/surveys/survey-validator/lib/survey_validator.dart
+++ b/surveys/survey-validator/lib/survey_validator.dart
@@ -49,6 +49,10 @@ const requiredKeys = {
   'excludeDashTools',
 };
 
+/// Regex pattern to valid UUID v4 format
+final uuidRegexPattern = RegExp(
+    r'^[0-9a-z]{8}\-[0-9a-z]{4}\-[0-9a-z]{4}\-[0-9a-z]{4}\-[0-9a-z]{12}$');
+
 /// The valid dash tools stored in the [DashTool] enum
 Set<String> get validDashTools => DashTool.values.map((e) => e.label).toSet();
 
@@ -96,6 +100,13 @@ void checkJson(File contextualSurveyFile) {
     }
     if (description.isEmpty) {
       throw ArgumentError('Description cannot be an empty string');
+    }
+
+    // Ensure that the client id is in the UUID v4 format
+    if (!uuidRegexPattern.hasMatch(uniqueId)) {
+      throw ArgumentError('Ensure that the unique ID for the survey is '
+          'valid UUID v4 format\n'
+          'Example: eca0100a-505b-4539-96d0-57235f816cef');
     }
 
     // Validation on the periods

--- a/surveys/survey-validator/lib/survey_validator.dart
+++ b/surveys/survey-validator/lib/survey_validator.dart
@@ -102,7 +102,7 @@ void checkJson(File contextualSurveyFile) {
       throw ArgumentError('Description cannot be an empty string');
     }
 
-    // Ensure that the client id is in the UUID v4 format
+    // Ensure that the survey's ID is a valid v4 UUID.
     if (!uuidRegexPattern.hasMatch(uniqueId)) {
       throw ArgumentError('Ensure that the unique ID for the survey is '
           'valid UUID v4 format for survey: $uniqueId\n'

--- a/surveys/survey-validator/lib/survey_validator.dart
+++ b/surveys/survey-validator/lib/survey_validator.dart
@@ -105,7 +105,7 @@ void checkJson(File contextualSurveyFile) {
     // Ensure that the client id is in the UUID v4 format
     if (!uuidRegexPattern.hasMatch(uniqueId)) {
       throw ArgumentError('Ensure that the unique ID for the survey is '
-          'valid UUID v4 format\n'
+          'valid UUID v4 format for survey: $uniqueId\n'
           'Example: eca0100a-505b-4539-96d0-57235f816cef');
     }
 

--- a/surveys/survey-validator/pubspec.lock
+++ b/surveys/survey-validator/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: eb376e9acf6938204f90eb3b1f00b578640d3188b4c8a8ec054f9f479af8d051
+      sha256: "36a321c3d2cbe01cbcb3540a87b8843846e0206df3e691fa7b23e19e78de6d49"
       url: "https://pub.dev"
     source: hosted
-    version: "64.0.0"
+    version: "65.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "69f54f967773f6c26c7dcb13e93d7ccee8b17a641689da39e878d5cf13b06893"
+      sha256: dfe03b90ec022450e22513b5e5ca1f01c0c01de9c3fba2f7fd233cb57a6b9a07
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.0"
+    version: "6.3.0"
   args:
     dependency: transitive
     description:
@@ -69,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "2fb815080e44a09b85e0f2ca8a820b15053982b2e714b59267719e8a9ff17097"
+      sha256: "595a29b55ce82d53398e1bcc2cba525d7bd7c59faeb2d2540e9d42c390cfeeeb"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.3"
+    version: "1.6.4"
   crypto:
     dependency: transitive
     description:
@@ -85,10 +85,10 @@ packages:
     dependency: "direct dev"
     description:
       name: dart_flutter_team_lints
-      sha256: "66517b1f6a53e3275938eece5fe0df6960d1e86a82bad074d7364a9a5c97ae10"
+      sha256: "0917c8b64a29532a7e6835e164131c89a5925fbf1e3a4319558b95f4ef623d64"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   file:
     dependency: transitive
     description:
@@ -165,10 +165,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
+      sha256: "5e5a8fdb6c327a998e3e14b611829e080b3bee14bdd9ae41bbc2efac77bc0dca"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "3.0.0-beta.2"
   logging:
     dependency: transitive
     description:
@@ -189,10 +189,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   mime:
     dependency: transitive
     description:
@@ -333,10 +333,10 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "9b0dd8e36af4a5b1569029949d50a52cb2a2a2fdaa20cebb96e6603b9ae241f9"
+      sha256: a20ddc0723556dc6dd56094e58ec1529196d5d7774156604cb14e8445a5a82ff
       url: "https://pub.dev"
     source: hosted
-    version: "1.24.6"
+    version: "1.24.7"
   test_api:
     dependency: transitive
     description:
@@ -349,10 +349,10 @@ packages:
     dependency: transitive
     description:
       name: test_core
-      sha256: "4bef837e56375537055fdbbbf6dd458b1859881f4c7e6da936158f77d61ab265"
+      sha256: "96382d0bc826e260b077bb496259e58bc82e90b603ab16cd5ae95dfe1dfcba8b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.6"
+    version: "0.5.7"
   typed_data:
     dependency: transitive
     description:
@@ -365,18 +365,18 @@ packages:
     dependency: "direct main"
     description:
       name: unified_analytics
-      sha256: "5394c375511a841fc53617bbbf947509cd939bb4275ad3ad0e378fc2e62c0c11"
+      sha256: c51b60656b45ff9f87ccc324661d70d9281e0f7b2c508dd6c3ece0de458afc16
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.1"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: c538be99af830f478718b51630ec1b6bee5e74e52c8a802d328d9e71d35d2583
+      sha256: a13d5503b4facefc515c8c587ce3cf69577a7b064a9f1220e005449cf1f64aad
       url: "https://pub.dev"
     source: hosted
-    version: "11.10.0"
+    version: "12.0.0"
   watcher:
     dependency: transitive
     description:


### PR DESCRIPTION
Includes an additional step in the json validator for contextual surveys to ensure each survey's `uniqueId` follows the UUID v4 format.

[This tool](https://www.uuidgenerator.net/version4) can be used to generate new IDs