### PR TITLE
Move up the JIT survey date

### DIFF
--- a/surveys/contextual-survey-metadata.json
+++ b/surveys/contextual-survey-metadata.json
@@ -1,7 +1,7 @@
 [
     {
         "uniqueId": "d27d24da-f789-45e3-83af-7ebaeade75c1",
-        "startDate": "2023-11-07T09:00:00-07:00",
+        "startDate": "2023-10-30T09:00:00-07:00",
         "endDate": "2023-11-21T09:00:00-07:00",
         "description": "Tell us about your target platform by taking this 3-question survey!",
         "snoozeForMinutes": 1440,


### PR DESCRIPTION
Moved up the JIT survey date from Nov 7 to Oct 30, so we can do the final test using the VS Code flag. 

