### PR TITLE
Cloud Build config: only upload JSON files in surveys directory

### DIFF
--- a/cloudbuild/gcs.yaml
+++ b/cloudbuild/gcs.yaml
@@ -1,5 +1,5 @@
 steps:
 - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-  args: ['gsutil', 'cp', '-r', 'surveys', 'gs://flutter-uxr/']
+  args: ['gsutil', 'cp', 'surveys/*.json', 'gs://flutter-uxr/surveys']
 options:
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
The GitHub action was uploading everything in `surveys` to GCS, but we only want to upload the JSON files. Not source code. 